### PR TITLE
情報過多になるので最近更新頻度が少ないプラットフォームのリンクを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@
 |GitHub(友人と共同で運営しているOrganization)|[nekochans](https://github.com/nekochans)|
 |Qiita|[keitakn](https://qiita.com/keitakn)|
 |Zenn|[keitakn](https://zenn.dev/keitakn)|
-|npm|[nekonomokochan](https://www.npmjs.com/~nekonomokochan)|
-|Packagist|[nekonomokochan](https://packagist.org/profile/)|
-|Speaker Deck|https://speakerdeck.com/keitakn|
 
 # 得意な事
 


### PR DESCRIPTION
# 内容

表題の通り。活動が活発な物だけを記載するように変更。